### PR TITLE
fixes for GitHub rules using api-gateway

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "github": "0.2.4",
-    "lambda-cfn": "0.1.2",
+    "lambda-cfn": "0.1.3",
     "d3-queue": "2.0.3"
   },
   "devDependencies": {

--- a/rules/2faDisabled.js
+++ b/rules/2faDisabled.js
@@ -107,10 +107,12 @@ module.exports.fn = function(event, callback) {
         subject: 'Error: Github 2FA check',
         summary: err
       };
+      console.log(err);
       message(notif, function(err,result) {
         return callback(err,result);
       });
     }
+    console.log(res[1]);
     callback(err, res[1]);
   });
 };

--- a/rules/madePublic.js
+++ b/rules/madePublic.js
@@ -1,30 +1,37 @@
 var message = require('lambda-cfn').message;
 var splitOnComma = require('lambda-cfn').splitOnComma;
 var util = require('util');
+var assert = require('assert');
 
 module.exports.config = {
   name: 'madePublic',
   sourcePath: 'rules/madePublic.js',
   gatewayRule: {
     method: 'POST',
-    apiKey: true
+    apiKey: false
   }
 };
 
 module.exports.fn = function(event,callback) {
-  var notif;
-  if (event.sender.login && event.repository.name) {
-    notif = {
-      subject: (util.format('Private repository %s made public by %s', event.repository.name, event.sender.login)).substring(0,100),
-      summary: util.format('The private repository %s was made by public by github user %s at %s\\n\\nRepo: %s\\n\\nUser: %s', event.repository.name,event.sender.login, event.repository.updated_at, event.repository.html_url, event.sender.html_url)
-    };
+  if (event.zen != undefined) {
+    var ping = 'GitHub ping event received';
+    console.log(ping);
+    return callback(null, ping);
   } else {
-    notif = {
-      subject: util.format('Error detected in Github made-repository-public webhook payload'),
-      summary: util.format('Malformed payload from Github made-repository-public webhook, see https://developer.github.com/v3/activity/events/types/#publicevent\\n\\n %s', JSON.stringify(event))
-    };
+    if (event.sender && event.repository && event.sender.login && event.repository.name) {
+      var notif = {
+        subject: (util.format('Private repository %s made public by %s', event.repository.name, event.sender.login)).substring(0,100),
+        summary: util.format('The private repository %s was made by public by github user %s at %s\nRepo: %s\nUser: %s', event.repository.name,event.sender.login, event.repository.updated_at, event.repository.html_url, event.sender.html_url),
+        event: event
+      };
+      message(notif, function(err,result) {
+        console.log(JSON.stringify(notif));
+        return callback(err,result);
+        });
+    } else {
+      var badmsg = 'Error: unknown payload received';
+      console.log(badmsg);
+      return callback(badmsg);
+    }
   }
-  message(notif, function(err,result) {
-    return callback(err,result);
-  });
 };

--- a/rules/privateRepoFork.js
+++ b/rules/privateRepoFork.js
@@ -7,28 +7,36 @@ module.exports.config = {
   sourcePath: 'rules/privateRepoFork.js',
   gatewayRule: {
     method: 'POST',
-    apiKey: true
+    apiKey: false
   }
 };
 
 module.exports.fn = function(event,callback) {
-  var notif;
-  if (event.forkee.owner.login && event.repository.name) {
-    if (event.repository.private) {
-      notif = {
-        subject: (util.format('Private repository %s forked by %s', event.repository.name, event.forkee.owner.login)).substring(0,100),
-        summary: util.format('The private repository %s was forked by github user %s at %s to forked repo %s\\n\\nSource repo: %s\\n\\nForked repo: %s\\n\\nUser: %s', event.repository.name, event.forkee.owner.login, event.forkee.updated_at, event.forkee.name, event.repository.html_url, event.forkee.html_url, event.forkee.owner.html_url)
-      };
-    } else {
-      return callback(null,util.format('Public repository %s forked by %s', event.repository.name, event.forkee.owner.login));
-    }
+  if (event.zen != undefined) {
+    var ping = 'GitHub ping event received';
+    console.log(ping);
+    return callback(null,ping);
   } else {
-    notif = {
-      subject: util.format('Error detected in Github private-repo-fork webhook payload'),
-      summary: util.format('Malformed payload from Github private-repo-fork webhook, see https://developer.github.com/v3/activity/events/types/#forkevent\\n\\n %s', JSON.stringify(event))
-    };
+    if (event.forkee && event.repository && event.repository.name && event.forkee.owner && event.forkee.owner.login) {
+      if (event.repository.private) {
+        var notif = {
+          subject: (util.format('Private repository %s forked by %s', event.repository.name, event.forkee.owner.login)).substring(0,100),
+          summary: util.format('The private repository %s was forked by github user %s at %s to forked repo %s\nSource repo: %s\nForked repo: %s\nUser: %s', event.repository.name, event.forkee.owner.login, event.forkee.updated_at, event.forkee.name, event.repository.html_url, event.forkee.html_url, event.forkee.owner.html_url),
+          event: event
+        };
+        message(notif, function(err,result) {
+          console.log(notif.subject + '\n' + notif.summary);
+          return callback(err, result);
+        });
+      } else {
+        var publicMsg = util.format('Public repository %s forked by %s', event.repository.name, event.forkee.owner.login);
+        console.log(publicMsg);
+        return callback(null, publicMsg);
+      }
+    } else {
+      var badMsg = 'Error: unknown payload received';
+      console.log(badMsg);
+      return callback(badMsg);
+    }
   }
-  message(notif, function(err,result) {
-    return callback(err,result);
-  });
 };

--- a/test/rules/madePublic.test.js
+++ b/test/rules/madePublic.test.js
@@ -36,6 +36,9 @@ var longWebhook = {
   }
 };
 
+var githubPing = {
+  zen: 'test'
+};
 
 var goodResponse = {
   subject: 'Private repository good-repo made public by testuser'
@@ -48,6 +51,19 @@ var badResponse = {
 
 var longResponse = 'Private repository xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
 
+test('GitHub ping', function(t) {
+  rule.fn(githubPing, function(err, message) {
+    t.equal(message,'GitHub ping event received');
+    t.end();
+  });
+});
+
+test('Unknown payload', function(t) {
+  rule.fn('{"random":"payload"}', function(err, message) {
+    t.equal(err,'Error: unknown payload received');
+    t.end();
+  });
+});
 
 test('Well formed webhook payload', function(t) {
   rule.fn(goodWebhook, function(err,message) {
@@ -58,7 +74,7 @@ test('Well formed webhook payload', function(t) {
 
 test('Malformed webhook payload', function(t) {
   rule.fn(badWebhook, function(err,message) {
-    t.equal(message.subject,badResponse.subject,'Subject line matched');
+    t.equal(err,'Error: unknown payload received');
     t.end();
   });
 });

--- a/test/rules/privateRepoFork.test.js
+++ b/test/rules/privateRepoFork.test.js
@@ -20,15 +20,19 @@ var privateFork = {
 
 var publicFork = {
   forkee: {
-    owner: {
-      login: 'defunkt'
+    name: 'forked-repo',
+    updated_at: '2011-11-11T11:11:11Z',
+    html_url: 'https://github.com/test/forked-repo',
+    owner:  {
+      login: 'defunkt',
+      html_url: 'https://github.com/defunkt'
     }
   },
   repository: {
     name: 'public-repo',
+    html_url: 'https://github.com/github/github-services',
     private: false
   }
-
 };
 
 var badPrivateFork = {
@@ -48,31 +52,47 @@ var badPrivateFork = {
   }
 };
 
-var goodResponse = {
-  subject: 'Private repository good-repo forked by defunkt'
+var githubPing = {
+  zen: 'test'
 };
+
+var goodResponse = 'Private repository good-repo forked by defunkt';
 
 var publicResponse = 'Public repository public-repo forked by defunkt';
 
 var badResponse = 'Error detected in Github private-repo-fork webhook payload';
 
+test('GitHub ping', function(t) {
+  rule.fn(githubPing, function(err, message) {
+    t.equal(message,'GitHub ping event received');
+    t.end();
+  });
+});
+
+test('Unknown payload', function(t) {
+  rule.fn({random:"payload"}, function(err, message) {
+    t.equal(err,'Error: unknown payload received');
+    t.end();
+  });
+});
+
 test('Well formed private fork webhook payload', function(t) {
-  rule.fn(privateFork, function(err,message) {
-    t.equal(message.subject, goodResponse.subject, 'Found forked private repo');
+  rule.fn(privateFork, function(err, message) {
+    t.equal(message.subject, goodResponse, 'Found forked private repo');
     t.end();
   });
 });
 
 test('Well formed public repo fork webhook payload', function(t) {
-  rule.fn(publicFork, function(err,message) {
+  rule.fn(publicFork, function(err, message) {
     t.equal(message, publicResponse, 'Found public repo fork');
     t.end();
   });
 });
 
 test('Malformed repo fork webhook payload', function(t) {
-  rule.fn(badPrivateFork, function(err,message) {
-    t.equal(message.subject, badResponse, 'Found malformed repo fork');
+  rule.fn(badPrivateFork, function(err, message) {
+    t.equal(err,'Error: unknown payload received');
     t.end();
   });
 });


### PR DESCRIPTION
Handle the ping that GitHub sends out when creating webhook. Cleaned up the function logic. Removed API Key since GitHub does not support it. 