### PR TITLE
Force push

### DIFF
--- a/rules/forcePush.js
+++ b/rules/forcePush.js
@@ -1,0 +1,36 @@
+var message = require('lambda-cfn').message;
+var splitOnComma = require('lambda-cfn').splitOnComma;
+var util = require('util');
+
+module.exports.config = {
+  name: 'forcePush',
+  sourcePath: 'rules/forcePush.js',
+  gatewayRule: {
+    method: 'POST',
+    apiKey: false
+  }
+};
+
+module.exports.fn = function(event,callback) {
+  if (event.zen != undefined) {
+    var ping = 'GitHub ping event received';
+    console.log(ping);
+    return callback(null, ping);
+  } else {
+    if (event.forced && event.repository && event.pusher) {
+      var notif = {
+        subject: (util.format('Force push on %s by %s', event.repository.name, event.pusher.name)).substring(0,100),
+        summary: util.format('%s force pushed to %s', event.pusher.name, event.repository.name),
+        event: event
+      };
+      message(notif, function(err,result) {
+        console.log(JSON.stringify(notif));
+        return callback(err,result);
+        });
+    } else {
+      var badmsg = 'Error: unknown payload received';
+      console.log(badmsg);
+      return callback(badmsg);
+    }
+  }
+};

--- a/rules/forcePush.js
+++ b/rules/forcePush.js
@@ -13,10 +13,12 @@ module.exports.config = {
 
 module.exports.fn = function(event,callback) {
   if (event.zen != undefined) {
+    console.log('event zen');
     var ping = 'GitHub ping event received';
     console.log(ping);
     return callback(null, ping);
   } else {
+    console.log('event okay');
     if (event.forced && event.repository && event.pusher) {
       var notif = {
         subject: (util.format('Force push on %s by %s', event.repository.name, event.pusher.name)).substring(0,100),
@@ -24,6 +26,7 @@ module.exports.fn = function(event,callback) {
         event: event
       };
       message(notif, function(err,result) {
+        if(err) console.log('error ', err);
         console.log(JSON.stringify(notif));
         return callback(err,result);
         });

--- a/rules/madePublic.js
+++ b/rules/madePublic.js
@@ -24,6 +24,7 @@ module.exports.fn = function(event,callback) {
         event: event
       };
       message(notif, function(err,result) {
+        if(err) console.log(err);
         console.log(JSON.stringify(notif));
         return callback(err,result);
         });

--- a/test/rules/forcePush.test.js
+++ b/test/rules/forcePush.test.js
@@ -1,0 +1,31 @@
+var test = require('tape');
+var rule = require('../../rules/forcePush.js');
+var testData = {
+  forced: true,
+  repository: {
+    name: "public-repo"
+    },
+  pusher: {
+    name: "arunasank",
+    email: "aruna@mapbox.com"
+  }
+};
+
+var githubPing = {
+  zen: 'test'
+};
+
+test('GitHub ping', function(t) {
+  rule.fn(githubPing, function(err, message) {
+    t.equal(message,'GitHub ping event received');
+    t.end();
+  });
+});
+
+test('Well formed webhook payload', function(t) {
+  rule.fn(testData, function(err,message) {
+    // t.equal(message.event, testData,'events matched');
+    console.log('######## msg ',message);
+    t.end();
+  });
+});


### PR DESCRIPTION
Detects force pushes to a repository.

<img width="793" alt="screen shot 2016-06-15 at 10 47 10 am" src="https://cloud.githubusercontent.com/assets/3166852/16084687/acce5780-32e7-11e6-8a90-53ef810ede5c.png">
(_force push to master_)

<img width="798" alt="screen shot 2016-06-15 at 10 55 58 am" src="https://cloud.githubusercontent.com/assets/3166852/16084717/c657eb1c-32e7-11e6-9f30-091bfd1f72c0.png">
(_force push to mybranch_)

Currently detects force pushes to every branch, but we probably just want to detect force pushes to master right? I can detect this by checking if the `ref` contains the `master_branch` value.

cc/ @zackmully 
