### PR TITLE
Handle repo creation event in madePublic patrol rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 sudo: false
 node_js:
 - 6.10.2
+- 8.10

--- a/lib/madePublic/event.js
+++ b/lib/madePublic/event.js
@@ -12,7 +12,11 @@ function madePublic(event, notify, callback) {
   let isPingEvent = event.zen !== undefined;
   if (!isPingEvent) {
 
-    if (event.sender && event.repository && event.sender.login && event.repository.name) {
+    if (event.action && event.action !== 'created') {
+      return callback(null, `The repository ${event.repository.name} was was not created. Action ${event.action}`);
+    }
+
+    if (event.sender && event.repository && event.sender.login && event.repository.name && event.repository.private === false) {
       return notify(event, callback);
     }
 

--- a/test/madePublic.test.js
+++ b/test/madePublic.test.js
@@ -5,7 +5,8 @@ var goodWebhook = {
   repository: {
     name: 'good-repo',
     html_url: 'https://github.com/test/testproject',
-    updated_at: '2011-11-11T11:11:11Z'
+    updated_at: '2011-11-11T11:11:11Z',
+    private: false
   },
   sender: {
     login: 'testuser',
@@ -28,7 +29,8 @@ var longWebhook = {
   repository: {
     name: Array(200).join('x'),
     html_url: 'https://github.com/test/testproject',
-    updated_at: '2011-11-11T11:11:11Z'
+    updated_at: '2011-11-11T11:11:11Z',
+    private: false
   },
   sender: {
     login: 'testuser',
@@ -45,6 +47,48 @@ var goodResponse = {
 };
 
 var longResponse = 'Private repository xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+
+var deletedPrivateHookEvent = {
+  action: 'deleted',
+  repository: {
+    name: 'good-repo',
+    html_url: 'https://github.com/test/testproject',
+    updated_at: '2011-11-11T11:11:11Z',
+    private: false
+  },
+  sender: {
+    login: 'testuser',
+    html_url: 'https://github.com/testuser'
+  }
+};
+
+var createdPrivateHookEvent = {
+  action: 'created',
+  repository: {
+    name: 'good-repo',
+    html_url: 'https://github.com/test/testproject',
+    updated_at: '2011-11-11T11:11:11Z',
+    private: false
+  },
+  sender: {
+    login: 'testuser',
+    html_url: 'https://github.com/testuser'
+  }
+};
+
+var createdPublicHookEvent = {
+  action: 'created',
+  repository: {
+    name: 'good-repo',
+    html_url: 'https://github.com/test/testproject',
+    updated_at: '2011-11-11T11:11:11Z',
+    private: false
+  },
+  sender: {
+    login: 'testuser',
+    html_url: 'https://github.com/testuser'
+  }
+};
 
 test('GitHub ping', function(t) {
   rule.fn(githubPing, {}, function(err, message) {
@@ -77,10 +121,40 @@ test('Malformed webhook payload', function(t) {
 });
 
 test('Long subject line truncation', function(t) {
-  rule.fn(longWebhook, {}, function(err,message) {
+  rule.fn(longWebhook, {}, function(err, message) {
     t.error(err, 'does not error');
     t.equal((message.subject).length, 100, 'Subject line 100 characters long');
     t.equal(message.subject, longResponse, 'Subject line truncation validation');
+    t.end();
+  });
+});
+
+test('It should trigger a message when the repo is not created', function(t) {
+  rule.fn(deletedPrivateHookEvent, {}, function(err, _message) {
+    t.error(err, 'The repository good-repo was not created. Action deleted');
+    t.end();
+  });
+});
+
+test('It should trigger a message when the repo is not created', function(t) {
+  rule.fn(deletedPrivateHookEvent, {}, function(err, _message) {
+    t.error(err, 'Error: unknown payload received');
+    t.end();
+  });
+});
+
+test('It should trigger a message when the repo is not created', function(t) {
+  rule.fn(createdPublicHookEvent, {}, function(err, message) {
+    t.error(err, 'does not error');
+    t.equal(message.subject, 'Private repository good-repo made public by testuser');
+    t.end();
+  });
+});
+
+test('It should trigger a message when the repo is not created', function(t) {
+  rule.fn(createdPrivateHookEvent, {}, function(err, _message) {
+    t.error(err, 'does not error');
+    t.error(err, 'Error: unknown payload received');
     t.end();
   });
 });


### PR DESCRIPTION
This PR allows to send a patrol message when a user creates a public repository.